### PR TITLE
Add option to select InstallDir

### DIFF
--- a/automatic/ninja/tools/chocolateyInstall.ps1
+++ b/automatic/ninja/tools/chocolateyInstall.ps1
@@ -1,14 +1,21 @@
 ﻿
 $ErrorActionPreference = 'Stop';
-$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$pp = Get-PackageParameters
+
+$installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+if ( $pp.InstallDir ) {
+  $installDir = $pp.InstallDir
+}
+
 $zipFile    = Get-Item "$toolsDir\ninja-win*.zip"
 #$zipFile64  = Get-Item "$toolsDir\*-x86_64-pc-windows-gnu*.zip"
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  destination   = $toolsDir
+  destination   = $installDir
   filefullpath  = $zipFile
   #filefullpath64= $zipFile64
 }
 
 Get-ChocolateyUnzip @packageArgs
+Write-Host "Installed to: '$installDir'"


### PR DESCRIPTION
If `InstallDir` parameter specified, it will unzip the ninja binaries to that certain location.
If not specified it will do the same as before, unzipping to the default location.