### PR TITLE
Fix issue where Shotcut is always one version behind

### DIFF
--- a/automatic/Shotcut/update.ps1
+++ b/automatic/Shotcut/update.ps1
@@ -15,7 +15,7 @@ function global:au_GetLatest {
 
     # https://github.com/mltframework/shotcut/releases/download/v18.03/shotcut-win64-180306.zip
     $re_64  = "shotcut-win64-.+.zip"
-    $url64 = $download_page.links | ? href -match $re_64 | select -First 1 -Skip 1 -expand href
+    $url64 = $download_page.links | ? href -match $re_64 | select -First 1 -expand href
 
     $url64 = "https://github.com" + $url64
 

--- a/automatic/shotcut.install/update.ps1
+++ b/automatic/shotcut.install/update.ps1
@@ -16,7 +16,7 @@ function global:au_GetLatest {
 
     # https://github.com/mltframework/shotcut/releases/download/v18.03/shotcut-win64-180306.exe
     $re_64  = "shotcut-win64-.+.exe"
-    $url64 = $download_page.links | ? href -match $re_64 | select -First 1 -Skip 1 -expand href
+    $url64 = $download_page.links | ? href -match $re_64 | select -First 1 -expand href
 
     $url64 = "https://github.com" + $url64
 

--- a/automatic/shotcut.portable/update.ps1
+++ b/automatic/shotcut.portable/update.ps1
@@ -16,7 +16,7 @@ function global:au_GetLatest {
 
     # https://github.com/mltframework/shotcut/releases/download/v18.03/shotcut-win64-180306.zip
     $re_64  = "shotcut-win64-.+.zip"
-    $url64 = $download_page.links | ? href -match $re_64 | select -First 1 -Skip 1 -expand href
+    $url64 = $download_page.links | ? href -match $re_64 | select -First 1 -expand href
 
     $url64 = "https://github.com" + $url64
 


### PR DESCRIPTION
Due to the `-Skip 1` the first version in the list (the newest one) was always skipped, which meant that a preview version was the newest available on Chocolatey even though the stable was already released. (And the preview was only added to Chocolatey after the stable release.)