### PR TITLE
Fix Windscribe AU

### DIFF
--- a/automatic/windscribe/update.ps1
+++ b/automatic/windscribe/update.ps1
@@ -1,5 +1,9 @@
 Import-Module au
 
+function global:au_BeforeUpdate {
+  $Latest.Checksum64 = Get-RemoteChecksum -Url $Latest.Url64 -Algorithm sha256
+}
+
 function global:au_SearchReplace {
     @{
         'tools\chocolateyinstall.ps1' = @{
@@ -47,4 +51,4 @@ function global:au_GetLatest {
   return @{ Streams = $streams }
 }
 
-Update-Package -ChecksumFor 64 -NoReadme
+Update-Package -ChecksumFor None -NoReadme


### PR DESCRIPTION
Fixes #22. Follow-up change for #21.

It doesn't seem that AU will attempt installation of new dependencies when executing a package's install script for automatic checksum calculation, which causes problems in the case of functions provided by a Chocolatey extension package. The AppVeyor CI environment won't be aware of the new function provided and therefore fails.

Theoretically could be fixed by tweaking AppVeyor's build script to pull down required extension packages ahead of time, but brittle since it could fail in other ways (e.g an OS dependency conflicts with the build environment).

Reimplementing checksum calculation to use `Get-RemoteChecksum` instead to avoid the need for install script execution.