### PR TITLE
`windscribe`: Updated pattern for asset filename

### DIFF
--- a/automatic/windscribe/update.ps1
+++ b/automatic/windscribe/update.ps1
@@ -24,15 +24,15 @@ function global:au_GetLatest {
     $json = ConvertFrom-Json $response
 
     # Release: Windscribe_2.11.11.exe
-    $re_release     = "^Windscribe_[^A-Za-z]+.exe$"
+    $re_release= "^Windscribe_[^A-Za-z]+_amd64.exe$"
     $release_data   = $null
 
     # Beta: Windscribe_2.12.4_beta.exe
-    $re_beta     = "^Windscribe_[^A-Za-z]+_beta.exe$"
+    $re_beta= "^Windscribe_[^A-Za-z]+_beta_amd64.exe$"
     $beta_data   = $null
 
     # Alpha: Windscribe_2.12.1_guinea_pig.exe
-    $re_alpha     = "^Windscribe_[^A-Za-z]+_guinea_pig.exe$"
+    $re_alpha= "^Windscribe_[^A-Za-z]+_guinea_pig_amd64.exe$"
     $alpha_data   = $null
 
     foreach ($release in $json) {


### PR DESCRIPTION
`windscribe`'s update script has not been behaving as expected since [v2.15.3-alpha](https://github.com/Windscribe/Desktop-App/releases/tag/v2.15.3)'s release.

Specifically, this build introduced ARM64 support, which prompted a file rename to clarify the installer's intended architecture. As the newer releases contain no such asset matching the old pattern, they have effectively been skipped over in favor of an older release.

Resolved with an update to each stream's expected file name pattern, to match against the new file name for the AMD64 installer historically consumed by this package.

Validated with a local execution after defining `github_api_key` with my own token. The updated script correctly returned the latest values (currently `2.15.8` for release, `2.16.6` for alpha, `2.16.8` for beta), and built each package as expected.